### PR TITLE
remove addresses from issue title

### DIFF
--- a/scripts/reduce_sql.py
+++ b/scripts/reduce_sql.py
@@ -49,6 +49,7 @@ def sanitize_error(err):
     err = err.replace(os.getcwd(), '')
     err = re.sub(r'LINE \d+:.*\n', '', err)
     err = re.sub(r' *\^ *', '', err)
+    err = re.sub(r'0[xX][0-9a-fA-F]+', '', err)
     if 'AddressSanitizer' in err:
         match = re.search(r'[ \t]+[#]0 ([A-Za-z0-9]+) ([^\n]+)', err).groups()[1]
         err = 'AddressSanitizer error ' + match


### PR DESCRIPTION
This PR contains a fix for: https://github.com/duckdblabs/duckdb-internal/issues/4206

The workflows in `duckdb-fuzzer-ci` run script `run_fuzzer.py` from repo `duckdb/duckdb-sqlsmith`
In case of bugs found by the fuzzer `run_fuzzer.py` files an issue, but only if the the error message is unique (to prevent duplicates).
The problem is that the error messages contain pointer addresses and therefore are considered unique.
This leads to the duplicate issues: https://github.com/duckdblabs/duckdb-internal/issues/4206

This PR cleans hex-addresses from the error messages, and therefore prevents duplicates.

original error (e.g. https://github.com/duckdb/duckdb-fuzzer/issues/3990)
```
ABORT THROWN BY INTERNAL EXCEPTION: Assertion triggered in file "/home/runner/work/duckdb-fuzzer-ci/duckdb-fuzzer-ci/src/common/types/hugeint.cpp" on line 129: lhs.upper >= 0 ../duckdb(+0x18efd814) [0x55e53f87e814] ../duckdb(+0x18dd1d3d)
```

error after sanitzing:
```
ABORT THROWN BY INTERNAL EXCEPTION: Assertion triggered in file "/home/runner/work/duckdb-fuzzer-ci/duckdb-fuzzer-ci/src/common/types/hugeint.cpp" on line 129: lhs.upper >= 0 ../duckdb(+) [] ../duckdb(+) 
```