### PR TITLE
Remove stack trace from issue title

### DIFF
--- a/scripts/fuzzer_helper.py
+++ b/scripts/fuzzer_helper.py
@@ -73,7 +73,7 @@ def make_github_issue(title, body):
         raise Exception("Failed to create issue")
 
 
-def get_github_issues(page):
+def get_github_issues(page: int) -> list[dict]:
     session = create_session()
     url = issue_url() + '?per_page=100&page=' + str(page)
     r = session.get(url)
@@ -164,10 +164,10 @@ def test_reproducibility(shell, issue, current_errors, perform_check):
     return True
 
 
-def extract_github_issues(shell, perform_check):
-    current_errors = dict()
+def extract_github_issues(shell, perform_check) -> dict[str, dict]:
+    current_errors: dict[str, dict] = dict()
     for p in range(1, 10):
-        issues = get_github_issues(p)
+        issues: list[dict] = get_github_issues(p)
         for issue in issues:
             # check if the github issue is still reproducible
             if not test_reproducibility(shell, issue, current_errors, perform_check):

--- a/scripts/fuzzer_helper.py
+++ b/scripts/fuzzer_helper.py
@@ -119,10 +119,16 @@ def label_github_issue(number, label):
 
 def extract_issue(body, nr):
     try:
-        sql = body.split(sql_header)[1].split(exception_header)[0]
-        exception = body.split(exception_header)[1].split(trace_header)[0]
-        trace = body.split(trace_header)[1].split(footer)[0]
-        return (sql, exception, trace)
+        if trace_header in body:
+            sql = body.split(sql_header)[1].split(exception_header)[0]
+            error = body.split(exception_header)[1].split(trace_header)[0]
+            trace = body.split(trace_header)[1].split(footer)[0]
+        else:
+            splits = body.split(exception_header)
+            sql = splits[0].split(sql_header)[1]
+            error = splits[1][: -len(footer)]
+            trace = ""
+        return (sql, error, trace)
     except:
         print(f"Failed to extract SQL/error message from issue {nr}")
         print(body)

--- a/scripts/reduce_sql.py
+++ b/scripts/reduce_sql.py
@@ -43,18 +43,6 @@ class MultiStatementManager:
         return self.statements[-1]
 
 
-def sanitize_error(err):
-    err = re.sub(r'Error: near line \d+: ', '', err)
-    err = err.replace(os.getcwd() + '/', '')
-    err = err.replace(os.getcwd(), '')
-    err = re.sub(r'LINE \d+:.*\n', '', err)
-    err = re.sub(r' *\^ *', '', err)
-    if 'AddressSanitizer' in err:
-        match = re.search(r'[ \t]+[#]0 ([A-Za-z0-9]+) ([^\n]+)', err).groups()[1]
-        err = 'AddressSanitizer error ' + match
-    return err.strip()
-
-
 def run_shell_command(shell, cmd):
     command = [shell, '-csv', '--batch', '-init', '/dev/null']
 
@@ -96,7 +84,7 @@ def reduce(sql_query, data_load, shell, error_msg, max_time_seconds=300):
                 break
 
             (stdout, stderr, returncode) = run_shell_command(shell, data_load + reduce_candidate)
-            new_error = sanitize_error(stderr)
+            new_error, _ = fuzzer_helper.split_exception_trace(stderr)
             if new_error == error_msg:
                 sql_query = reduce_candidate
                 found_new_candidate = True
@@ -147,9 +135,9 @@ def run_queries_until_crash_mp(local_shell, data_load, queries, result_file):
 
         keep_query = is_ddl_query(q)
         (stdout, stderr, returncode) = run_shell_command(local_shell, '\n'.join(data_load) + ';' + q)
-     
+
         is_internal_error = fuzzer_helper.is_internal_error(stderr)
-        exception_error = sanitize_error(stderr).strip()
+        exception_error, _ = fuzzer_helper.split_exception_trace(stderr)
         if is_internal_error and len(expected_error) > 0:
             keep_query = True
             sqlite_con.execute('UPDATE result SET text=?', (exception_error,))
@@ -232,7 +220,7 @@ def reduce_multi_statement(sql_queries, local_shell, local_data_load, max_time=3
     last_statement = reducer.get_last_statement()
     print(f"testing if just last statement of multi statement creates the error")
     (stdout, stderr, returncode) = run_shell_command(local_shell, local_data_load + last_statement)
-    expected_error = sanitize_error(stderr).strip()
+    expected_error, _ = fuzzer_helper.split_exception_trace(stderr)
     if len(expected_error) > 0:
         print(f"Expected error is {expected_error}")
     else:
@@ -301,7 +289,7 @@ if __name__ == "__main__":
     sql_query = open(args.exec).read()
     verbose = args.verbose
     (stdout, stderr, returncode) = run_shell_command(shell, data_load + sql_query)
-    expected_error = sanitize_error(stderr).strip()
+    expected_error, _ = fuzzer_helper.split_exception_trace(stderr)
     if len(expected_error) == 0:
         print("===================================================")
         print("Could not find expected error - no error encountered")

--- a/scripts/reduce_sql.py
+++ b/scripts/reduce_sql.py
@@ -49,7 +49,6 @@ def sanitize_error(err):
     err = err.replace(os.getcwd(), '')
     err = re.sub(r'LINE \d+:.*\n', '', err)
     err = re.sub(r' *\^ *', '', err)
-    err = re.sub(r'0[xX][0-9a-fA-F]+', '', err)
     if 'AddressSanitizer' in err:
         match = re.search(r'[ \t]+[#]0 ([A-Za-z0-9]+) ([^\n]+)', err).groups()[1]
         err = 'AddressSanitizer error ' + match

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -183,8 +183,7 @@ if not fuzzer_helper.is_internal_error(stderr):
     print("Failed to reproduce the internal error")
     exit(0)
 
-error_msg = reduce_sql.sanitize_error(stderr)
-exception_msg, stacktrace = fuzzer_helper.split_exception_trace(error_msg)
+exception_msg, stacktrace = fuzzer_helper.split_exception_trace(stderr)
 
 print("=========================================")
 print("         Reproduced successfully         ")
@@ -210,8 +209,7 @@ cmd = create_db_statement + '\n' + required_queries
 
 # get a new error message.
 (stdout, stderr, returncode) = run_shell_command(cmd)
-error_msg = reduce_sql.sanitize_error(stderr)
-exception_msg, stacktrace = fuzzer_helper.split_exception_trace(error_msg)
+exception_msg, stacktrace = fuzzer_helper.split_exception_trace(stderr)
 
 # check if this is a duplicate issue
 if exception_msg in current_errors:

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -61,7 +61,7 @@ if seed < 0:
 git_hash = os.getenv('DUCKDB_HASH')
 
 
-def create_db_script(db):
+def get_create_db_statement(db):
     if db == 'alltypes':
         return 'create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();'
     elif db == 'tpch':
@@ -72,7 +72,7 @@ def create_db_script(db):
         raise Exception("Unknown database creation script")
 
 
-def run_fuzzer_script(fuzzer):
+def get_fuzzer_call_statement(fuzzer):
     if fuzzer == 'sqlsmith':
         return "call sqlsmith(max_queries=${MAX_QUERIES}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
     elif fuzzer == 'duckfuzz':
@@ -83,7 +83,7 @@ def run_fuzzer_script(fuzzer):
         raise Exception("Unknown fuzzer type")
 
 
-def get_fuzzer_name(fuzzer):
+def get_fuzzer_name_printable(fuzzer):
     if fuzzer == 'sqlsmith':
         return 'SQLSmith'
     elif fuzzer == 'duckfuzz':
@@ -123,10 +123,9 @@ print(
 )
 
 
-load_script = create_db_script(db)
-fuzzer_name = get_fuzzer_name(fuzzer)
-fuzzer = (
-    run_fuzzer_script(fuzzer)
+create_db_statement = get_create_db_statement(db)
+call_fuzzer_statement = (
+    get_fuzzer_call_statement(fuzzer)
     .replace('${MAX_QUERIES}', str(max_queries))
     .replace('${LAST_LOG_FILE}', last_query_log_file)
     .replace('${COMPLETE_LOG_FILE}', complete_log_file)
@@ -134,10 +133,10 @@ fuzzer = (
     .replace('${ENABLE_VERIFICATION}', str(verification))
 )
 
-print(load_script)
-print(fuzzer)
+print(create_db_statement)
+print(call_fuzzer_statement)
 
-cmd = load_script + "\n" + fuzzer
+cmd = create_db_statement + "\n" + call_fuzzer_statement
 
 print("==========================================")
 
@@ -169,7 +168,7 @@ with open(last_query_log_file, 'r') as f:
 with open(complete_log_file, 'r') as f:
     all_queries = f.read()
 
-(stdout, stderr, returncode) = run_shell_command(load_script + '\n' + all_queries)
+(stdout, stderr, returncode) = run_shell_command(create_db_statement + '\n' + all_queries)
 
 if returncode == 0:
     print("Failed to reproduce the issue...")
@@ -205,8 +204,8 @@ print("=========================================")
 # try to reduce the query as much as possible
 # reduce_multi_statement checks just the last statement first as a heuristic to see if
 # only the last statement causes the error.
-required_queries = reduce_sql.reduce_multi_statement(all_queries, shell, load_script)
-cmd = load_script + '\n' + required_queries
+required_queries = reduce_sql.reduce_multi_statement(all_queries, shell, create_db_statement)
+cmd = create_db_statement + '\n' + required_queries
 
 # get a new error message.
 (stdout, stderr, returncode) = run_shell_command(cmd)
@@ -218,4 +217,5 @@ print(f"{error_msg}")
 print(f"================MARKER====================")
 
 if not no_git_checks:
-    fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name, seed, git_hash)
+    fuzzer_name_printable = get_fuzzer_name_printable(fuzzer)
+    fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name_printable, seed, git_hash)

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -105,9 +105,9 @@ def run_shell_command(cmd):
 # first get a list of all github issues, and check if we can still reproduce them
 
 if no_git_checks:
-    current_errors = []
+    current_errors: dict[str, dict] = dict()
 else:
-    current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
+    current_errors: dict[str, dict] = fuzzer_helper.extract_github_issues(shell, perform_checks)
 
 # Don't go on and fuzz if perform checks = true
 if perform_checks:

--- a/scripts/run_sqlancer.py
+++ b/scripts/run_sqlancer.py
@@ -129,13 +129,13 @@ print('----------------------------------------------')
 print(reduced_test_case)
 
 (stdout, stderr, returncode) = reduce_sql.run_shell_command(shell, reduced_test_case)
-error_msg = reduce_sql.sanitize_error(stderr)
+error_msg, _ = fuzzer_helper.split_exception_trace(stderr)
 
 print('----------------------------------------------')
 print("Fetching github issues")
 print('----------------------------------------------')
 
-# first get a list of all github issues, and check if we can still reproduce them
+# first get a dictinary of all github issues, and check if we can still reproduce them
 current_errors = fuzzer_helper.extract_github_issues(shell)
 
 # check if this is a duplicate issue


### PR DESCRIPTION
This PR  solves issue: https://github.com/duckdblabs/duckdb-internal/issues/4206

This PR splits the stack trace and the actual error message.
Only the error message (including the file and the line where the exception occurs) is used to determine uniqueness of the issue.
Note that issue https://github.com/duckdblabs/duckdb-fuzzer-ci/issues/43 is related, but not yet solved in this PR

### example issues, generated by workflow [CIFuzz](https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/workflows/cifuzz.yml)
Example of issue, without this change: https://github.com/duckdb/duckdb-fuzzer/issues/3990
Example of issue, with this change: https://github.com/duckdb/duckdb-fuzzer/issues/4077 -> stack trace in seperate heading


### tests executed: related to issue https://github.com/duckdb/duckdb-fuzzer/issues/4077
- Ran CIFuzz with old duckdb version, which created the [issue 4077](https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/13592225769) stack trace now seperate from title
- Ran CIFuzz again with same version of duckdb, to verify that the issue is not duplciated: https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/13627735826
- Ran CIFuzz again with latest version of duckdb, to verify that the issue is properly closed, since it can no longer be reproduced: https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/13634418374