### PR TITLE
Limit total length of fuzz statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testext
 scripts/__pycache__/
 test/python/__pycache__/
 .Rhistory
+.vscode

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -1,5 +1,3 @@
-import json
-import requests
 import sys
 import os
 import subprocess
@@ -15,6 +13,7 @@ shell = None
 perform_checks = True
 no_git_checks = False
 max_queries = 1000
+max_query_length = 40000
 verification = False
 
 for param in sys.argv:
@@ -40,6 +39,8 @@ for param in sys.argv:
         seed = int(param.replace('--seed=', ''))
     elif param.startswith('--max_queries='):
         max_queries = int(param.replace('--max_queries=', ''))
+    elif param.startswith('--max_query_length='):
+        max_query_length = int(param.replace('--max_query_length=', ''))
     elif param.startswith('--no-git-checks'):
         no_git_checks = param.replace('--no-git-checks=', '').lower() == 'true'
 
@@ -74,7 +75,7 @@ def get_create_db_statement(db):
 
 def get_fuzzer_call_statement(fuzzer):
     if fuzzer == 'sqlsmith':
-        return "call sqlsmith(max_queries=${MAX_QUERIES}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
+        return "call sqlsmith(max_queries=${MAX_QUERIES}, max_query_length=${MAX_QUERY_LENGTH}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
     elif fuzzer == 'duckfuzz':
         return "call fuzzyduck(max_queries=${MAX_QUERIES}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}', enable_verification='${ENABLE_VERIFICATION}');"
     elif fuzzer == 'duckfuzz_functions':
@@ -138,6 +139,7 @@ create_db_statement = get_create_db_statement(db)
 call_fuzzer_statement = (
     get_fuzzer_call_statement(fuzzer)
     .replace('${MAX_QUERIES}', str(max_queries))
+    .replace('${MAX_QUERY_LENGTH}', str(max_query_length))
     .replace('${LAST_LOG_FILE}', last_query_log_file)
     .replace('${COMPLETE_LOG_FILE}', complete_log_file)
     .replace('${SEED}', str(seed))

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -79,7 +79,7 @@ def get_fuzzer_call_statement(fuzzer):
     elif fuzzer == 'duckfuzz':
         return "call fuzzyduck(max_queries=${MAX_QUERIES}, max_query_length=${MAX_QUERY_LENGTH}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}', enable_verification='${ENABLE_VERIFICATION}');"
     elif fuzzer == 'duckfuzz_functions':
-        return "call fuzz_all_functions(seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
+        return "call fuzz_all_functions(seed=${SEED}, max_query_length=${MAX_QUERY_LENGTH}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
     else:
         raise Exception("Unknown fuzzer type")
 

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -13,7 +13,7 @@ shell = None
 perform_checks = True
 no_git_checks = False
 max_queries = 1000
-max_query_length = 40000
+max_query_length = 50000
 verification = False
 
 for param in sys.argv:
@@ -77,7 +77,7 @@ def get_fuzzer_call_statement(fuzzer):
     if fuzzer == 'sqlsmith':
         return "call sqlsmith(max_queries=${MAX_QUERIES}, max_query_length=${MAX_QUERY_LENGTH}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
     elif fuzzer == 'duckfuzz':
-        return "call fuzzyduck(max_queries=${MAX_QUERIES}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}', enable_verification='${ENABLE_VERIFICATION}');"
+        return "call fuzzyduck(max_queries=${MAX_QUERIES}, max_query_length=${MAX_QUERY_LENGTH}, seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}', enable_verification='${ENABLE_VERIFICATION}');"
     elif fuzzer == 'duckfuzz_functions':
         return "call fuzz_all_functions(seed=${SEED}, verbose_output=1, log='${LAST_LOG_FILE}', complete_log='${COMPLETE_LOG_FILE}');"
     else:

--- a/src/fuzzyduck.cpp
+++ b/src/fuzzyduck.cpp
@@ -49,9 +49,9 @@ void FuzzyDuck::Fuzz() {
 	for (idx_t i = 0; i < max_queries; i++) {
 		LogMessage("Query " + to_string(i) + "\n");
 		auto query = GenerateQuery(total_query_length);
-		total_query_length += query.size();
+		total_query_length += query.size() + 2; // add 2 for semicolon and newline
 		if (total_query_length > max_query_length) {
-			LogTask("Max query length (" + to_string(max_query_length) + ") reached.");
+			LogTask("Max query length (" + to_string(max_query_length) + ") reached");
 			break;
 		}
 		RunQuery(std::move(query));
@@ -69,8 +69,14 @@ void FuzzyDuck::FuzzAllFunctions() {
 
 	std::default_random_engine e(seed);
 	std::shuffle(std::begin(queries), std::end(queries), e);
+	idx_t total_query_length = 0;
 	BeginFuzzing();
 	for (auto &query : queries) {
+		total_query_length += query.size() + 2; // add 2 for semicolon and newline
+		if (total_query_length > max_query_length) {
+			LogTask("Max query length (" + to_string(max_query_length) + ") reached");
+			break;
+		}
 		RunQuery(std::move(query));
 	}
 	EndFuzzing();

--- a/src/fuzzyduck.cpp
+++ b/src/fuzzyduck.cpp
@@ -90,7 +90,7 @@ string FuzzyDuck::GenerateQuery(const idx_t &total_query_length) {
 	auto statement = string("");
 	if (generator.RandomPercentage(10)) {
 		// multi statement
-		idx_t number_of_statements = generator.RandomValue(100);
+		idx_t number_of_statements = generator.RandomValue(30);
 		idx_t length_multi_statement = 0;
 		string statement_i;
 		idx_t length_statement_to_add;

--- a/src/fuzzyduck.cpp
+++ b/src/fuzzyduck.cpp
@@ -51,6 +51,7 @@ void FuzzyDuck::Fuzz() {
 		auto query = GenerateQuery(total_query_length);
 		total_query_length += query.size() + 2; // add 2 for semicolon and newline
 		if (total_query_length > max_query_length) {
+			// break to prevent the query gets too large to process down-stream (e.g. should fit in issue tracker)
 			LogTask("Max query length (" + to_string(max_query_length) + ") reached");
 			break;
 		}
@@ -74,6 +75,7 @@ void FuzzyDuck::FuzzAllFunctions() {
 	for (auto &query : queries) {
 		total_query_length += query.size() + 2; // add 2 for semicolon and newline
 		if (total_query_length > max_query_length) {
+			// break to prevent the query gets too large to process down-stream (e.g. should fit in issue tracker)
 			LogTask("Max query length (" + to_string(max_query_length) + ") reached");
 			break;
 		}
@@ -98,6 +100,7 @@ string FuzzyDuck::GenerateQuery(const idx_t &total_query_length) {
 		for (idx_t i = 0; i < number_of_statements; i++) {
 			statement_i = generator.GenerateStatement()->ToString() + "; ";
 			length_statement_to_add = statement_i.size();
+			// break to prevent the query gets too large to process down-stream (e.g. should fit in issue tracker)
 			if (total_query_length + length_multi_statement + length_statement_to_add > max_query_length) {
 				break;
 			}

--- a/src/fuzzyduck.cpp
+++ b/src/fuzzyduck.cpp
@@ -29,7 +29,7 @@ void FuzzyDuck::BeginFuzzing() {
 		auto &fs = FileSystem::GetFileSystem(context);
 		TryRemoveFile(complete_log);
 		complete_log_handle =
-			fs.OpenFile(complete_log, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		    fs.OpenFile(complete_log, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	}
 	if (enable_verification) {
 		RunQuery("PRAGMA enable_verification");

--- a/src/fuzzyduck.cpp
+++ b/src/fuzzyduck.cpp
@@ -20,10 +20,10 @@ void FuzzyDuck::BeginFuzzing() {
 	}
 	random_engine.SetSeed(seed);
 	if (max_queries == 0) {
-		throw BinderException("Provide a max_queries argument greater than 0");
+		throw InvalidInputException("Provide a max_queries argument greater than 0");
 	}
 	if (max_query_length == 0) {
-		throw BinderException("Provide a max_query_length argument greater than 0");
+		throw InvalidInputException("Provide a max_query_length argument greater than 0");
 	}
 	if (!complete_log.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);

--- a/src/include/fuzzyduck.hpp
+++ b/src/include/fuzzyduck.hpp
@@ -22,6 +22,7 @@ public:
 	ClientContext &context;
 	uint32_t seed = 0;
 	idx_t max_queries = 0;
+	idx_t max_query_length = 0;
 	string complete_log;
 	string log;
 	bool verbose_output = false;
@@ -36,7 +37,7 @@ private:
 	void BeginFuzzing();
 	void EndFuzzing();
 
-	string GenerateQuery();
+	string GenerateQuery(const idx_t &total_query_length);
 	void RunQuery(string query);
 
 	void LogMessage(const string &message);

--- a/src/include/statement_generator.hpp
+++ b/src/include/statement_generator.hpp
@@ -102,7 +102,6 @@ private:
 	unique_ptr<OrderModifier> GenerateOrderBy();
 	unique_ptr<OrderModifier> GenerateOrderByAll();
 
-
 	LogicalType GenerateLogicalType();
 
 	void GenerateAllScalar(ScalarFunctionCatalogEntry &scalar_function, vector<string> &result);

--- a/src/include/statement_generator.hpp
+++ b/src/include/statement_generator.hpp
@@ -51,7 +51,7 @@ public:
 
 	vector<string> GenerateAllFunctionCalls();
 
-	//! Returns true with a percentage change (0-100)
+	//! Returns true with a percentage chance (0-100)
 	bool RandomPercentage(idx_t percentage);
 	bool verification_enabled = false;
 	idx_t RandomValue(idx_t max);

--- a/src/sqlsmith_extension.cpp
+++ b/src/sqlsmith_extension.cpp
@@ -231,5 +231,4 @@ extern "C" {
 DUCKDB_CPP_EXTENSION_ENTRY(sqlsmith, loader) {
 	duckdb::LoadInternal(loader);
 }
-
 }

--- a/src/sqlsmith_extension.cpp
+++ b/src/sqlsmith_extension.cpp
@@ -137,6 +137,8 @@ static duckdb::unique_ptr<FunctionData> FuzzyDuckBind(ClientContext &context, Ta
 			result->fuzzer.seed = IntegerValue::Get(kv.second);
 		} else if (kv.first == "max_queries") {
 			result->fuzzer.max_queries = UBigIntValue::Get(kv.second);
+		} else if (kv.first == "max_query_length") {
+			result->fuzzer.max_query_length = UBigIntValue::Get(kv.second);
 		} else if (kv.first == "complete_log") {
 			result->fuzzer.complete_log = StringValue::Get(kv.second);
 		} else if (kv.first == "log") {
@@ -189,6 +191,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TableFunction fuzzy_duck_fun("fuzzyduck", {}, FuzzyDuckFunction, FuzzyDuckBind);
 	fuzzy_duck_fun.named_parameters["seed"] = LogicalType::INTEGER;
 	fuzzy_duck_fun.named_parameters["max_queries"] = LogicalType::UBIGINT;
+	fuzzy_duck_fun.named_parameters["max_query_length"] = LogicalType::UBIGINT;
 	fuzzy_duck_fun.named_parameters["log"] = LogicalType::VARCHAR;
 	fuzzy_duck_fun.named_parameters["complete_log"] = LogicalType::VARCHAR;
 	fuzzy_duck_fun.named_parameters["verbose_output"] = LogicalType::BOOLEAN;

--- a/src/sqlsmith_extension.cpp
+++ b/src/sqlsmith_extension.cpp
@@ -200,6 +200,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	TableFunction fuzz_all_functions("fuzz_all_functions", {}, FuzzAllFunctions, FuzzyDuckBind);
 	fuzz_all_functions.named_parameters["seed"] = LogicalType::INTEGER;
+	fuzz_all_functions.named_parameters["max_query_length"] = LogicalType::UBIGINT;
 	fuzz_all_functions.named_parameters["log"] = LogicalType::VARCHAR;
 	fuzz_all_functions.named_parameters["complete_log"] = LogicalType::VARCHAR;
 	fuzz_all_functions.named_parameters["verbose_output"] = LogicalType::BOOLEAN;

--- a/src/sqlsmith_extension.cpp
+++ b/src/sqlsmith_extension.cpp
@@ -16,6 +16,7 @@ struct SQLSmithFunctionData : public TableFunctionData {
 
 	int32_t seed = -1;
 	idx_t max_queries = 0;
+	idx_t max_query_length = 0;
 	bool exclude_catalog = false;
 	bool dump_all_queries = false;
 	bool dump_all_graphs = false;
@@ -34,6 +35,8 @@ static duckdb::unique_ptr<FunctionData> SQLSmithBind(ClientContext &context, Tab
 			result->seed = IntegerValue::Get(kv.second);
 		} else if (kv.first == "max_queries") {
 			result->max_queries = UBigIntValue::Get(kv.second);
+		} else if (kv.first == "max_query_length") {
+			result->max_query_length = UBigIntValue::Get(kv.second);
 		} else if (kv.first == "exclude_catalog") {
 			result->exclude_catalog = BooleanValue::Get(kv.second);
 		} else if (kv.first == "dump_all_queries") {
@@ -62,6 +65,7 @@ static void SQLSmithFunction(ClientContext &context, TableFunctionInput &data_p,
 	duckdb_sqlsmith::SQLSmithOptions options;
 	options.seed = data.seed;
 	options.max_queries = data.max_queries;
+	options.max_query_length = data.max_query_length;
 	options.exclude_catalog = data.exclude_catalog;
 	options.dump_all_queries = data.dump_all_queries;
 	options.dump_all_graphs = data.dump_all_graphs;
@@ -173,6 +177,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TableFunction sqlsmith_func("sqlsmith", {}, SQLSmithFunction, SQLSmithBind);
 	sqlsmith_func.named_parameters["seed"] = LogicalType::INTEGER;
 	sqlsmith_func.named_parameters["max_queries"] = LogicalType::UBIGINT;
+	sqlsmith_func.named_parameters["max_query_length"] = LogicalType::UBIGINT;
 	sqlsmith_func.named_parameters["exclude_catalog"] = LogicalType::BOOLEAN;
 	sqlsmith_func.named_parameters["dump_all_queries"] = LogicalType::BOOLEAN;
 	sqlsmith_func.named_parameters["dump_all_graphs"] = LogicalType::BOOLEAN;

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -42,8 +42,8 @@ StatementGenerator::StatementGenerator(ClientContext &context) : context(context
 }
 
 StatementGenerator::StatementGenerator(StatementGenerator &parent_p)
-    : verification_enabled(parent_p.verification_enabled), context(parent_p.context), parent(&parent_p), 
-		generator_context(parent_p.generator_context), depth(parent_p.depth + 1) {
+    : verification_enabled(parent_p.verification_enabled), context(parent_p.context), parent(&parent_p),
+      generator_context(parent_p.generator_context), depth(parent_p.depth + 1) {
 	if (depth > MAX_DEPTH) {
 		throw InternalException("depth too high");
 	}
@@ -109,7 +109,7 @@ unique_ptr<SQLStatement> StatementGenerator::GenerateStatement() {
 	if (RandomPercentage(30)) {
 		return GenerateStatement(StatementType::SET_STATEMENT);
 	}
-	if (RandomPercentage(40)) { //20
+	if (RandomPercentage(40)) { // 20
 		return GenerateStatement(StatementType::DELETE_STATEMENT);
 	}
 	return GenerateStatement(StatementType::CREATE_STATEMENT);
@@ -196,7 +196,7 @@ unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
 	} else {
 		delete_statement->table = GenerateTableRef();
 	}
-	
+
 	return delete_statement;
 }
 
@@ -769,7 +769,7 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
 	case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
 		auto &aggregate_entry = function.Cast<AggregateFunctionCatalogEntry>();
 		auto actual_function =
-			aggregate_entry.functions.GetFunctionByOffset(RandomValue(aggregate_entry.functions.Size()));
+		    aggregate_entry.functions.GetFunctionByOffset(RandomValue(aggregate_entry.functions.Size()));
 
 		name = aggregate_entry.name;
 		min_parameters = actual_function.arguments.size();
@@ -819,26 +819,26 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
 }
 
 unique_ptr<OrderModifier> StatementGenerator::GenerateOrderByAll() {
-    auto result = make_uniq<OrderModifier>();
+	auto result = make_uniq<OrderModifier>();
 	auto order_type = Choose<OrderType>({OrderType::ASCENDING, OrderType::DESCENDING, OrderType::ORDER_DEFAULT});
 	auto null_type = Choose<OrderByNullType>(
-		{OrderByNullType::NULLS_FIRST, OrderByNullType::NULLS_LAST, OrderByNullType::ORDER_DEFAULT});
+	    {OrderByNullType::NULLS_FIRST, OrderByNullType::NULLS_LAST, OrderByNullType::ORDER_DEFAULT});
 	result->orders.emplace_back(order_type, null_type, GenerateStar());
-    return result;
+	return result;
 }
 
 unique_ptr<OrderModifier> StatementGenerator::GenerateOrderBy() {
-    auto result = make_uniq<OrderModifier>();
+	auto result = make_uniq<OrderModifier>();
 	while (true) {
 		auto order_type = Choose<OrderType>({OrderType::ASCENDING, OrderType::DESCENDING, OrderType::ORDER_DEFAULT});
 		auto null_type = Choose<OrderByNullType>(
-			{OrderByNullType::NULLS_FIRST, OrderByNullType::NULLS_LAST, OrderByNullType::ORDER_DEFAULT});
+		    {OrderByNullType::NULLS_FIRST, OrderByNullType::NULLS_LAST, OrderByNullType::ORDER_DEFAULT});
 		result->orders.emplace_back(order_type, null_type, GenerateExpression());
 		if (RandomPercentage(50)) {
 			break;
 		}
 	}
-    return result;
+	return result;
 }
 
 unique_ptr<ParsedExpression> StatementGenerator::GenerateOperator() {
@@ -1082,12 +1082,12 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateStar() {
 unique_ptr<ParsedExpression> StatementGenerator::GenerateLambda() {
 	// generate the lambda name and add the lambda column names to the set of possibly-generated column names
 	auto lambda_parameter = GenerateIdentifier();
-    vector<string> named_parameters;
-    named_parameters.push_back(lambda_parameter);
+	vector<string> named_parameters;
+	named_parameters.push_back(lambda_parameter);
 	auto rhs = GenerateExpression();
 	current_column_names.erase(std::find(current_column_names.begin(), current_column_names.end(), lambda_parameter));
 
-    return make_uniq<LambdaExpression>(std::move(named_parameters), std::move(rhs));
+	return make_uniq<LambdaExpression>(std::move(named_parameters), std::move(rhs));
 }
 
 string StatementGenerator::GenerateDataBaseName() {

--- a/src/third_party/sqlsmith/include/sqlsmith.hh
+++ b/src/third_party/sqlsmith/include/sqlsmith.hh
@@ -12,6 +12,7 @@ namespace duckdb_sqlsmith {
 struct SQLSmithOptions {
 	int32_t seed = -1;
 	uint64_t max_queries = 0;
+	uint64_t max_query_length = 0;
 	bool exclude_catalog = false;
 	bool dump_all_queries = false;
 	bool dump_all_graphs = false;

--- a/src/third_party/sqlsmith/sqlsmith.cc
+++ b/src/third_party/sqlsmith/sqlsmith.cc
@@ -160,6 +160,8 @@ int32_t run_sqlsmith(duckdb::DatabaseInstance &database, SQLSmithOptions opt) {
 				ostringstream s;
 				gen->out(s);
 
+				// break to prevent the query gets too large to process down-stream
+				// e.g. should fit in issue tracker
 				length_queries_generated += s.str().size();
 				if (opt.max_query_length > 0 && length_queries_generated > opt.max_query_length) {
 					if (global_cerr_logger)
@@ -167,8 +169,7 @@ int32_t run_sqlsmith(duckdb::DatabaseInstance &database, SQLSmithOptions opt) {
 					return 0;
 				}
 
-				// write the query to the complete log that has all the
-				// queries
+				// write the query to the complete log that has all the queries
 				if (has_complete_log) {
 					complete_log << s.str() << ";" << endl;
 					complete_log.flush();

--- a/src/third_party/sqlsmith/sqlsmith.cc
+++ b/src/third_party/sqlsmith/sqlsmith.cc
@@ -87,6 +87,7 @@ int32_t run_sqlsmith(duckdb::DatabaseInstance &database, SQLSmithOptions opt) {
 
 		scope scope;
 		long queries_generated = 0;
+		long length_queries_generated = 0;
 		schema->fill_scope(scope);
 
 		//		if (options.count("rng-state")) {
@@ -158,6 +159,13 @@ int32_t run_sqlsmith(duckdb::DatabaseInstance &database, SQLSmithOptions opt) {
 				/* Generate SQL from AST */
 				ostringstream s;
 				gen->out(s);
+
+				length_queries_generated += s.str().size();
+				if (opt.max_query_length > 0 && length_queries_generated > opt.max_query_length) {
+					if (global_cerr_logger)
+						global_cerr_logger->report();
+					return 0;
+				}
 
 				// write the query to the complete log that has all the
 				// queries

--- a/test/sql/call_fuzzyduck.test
+++ b/test/sql/call_fuzzyduck.test
@@ -7,9 +7,9 @@ mode skip
 require sqlsmith
 
 statement ok
-call fuzzyduck(max_queries=2, verbose_output=1, log='sqlsmith.log', complete_log='sqlsmith.complete.log', enable_verification=True);
+call fuzzyduck(max_queries=2, max_query_length=50000, verbose_output=1, log='sqlsmith.log', complete_log='sqlsmith.complete.log', enable_verification=True);
 
 statement ok
-call fuzzyduck(max_queries=2, verbose_output=1, log='__TEST_DIR__/logs.txt', complete_log='__TEST_DIR__/clog.txt', enable_verification=false);
+call fuzzyduck(max_queries=2, max_query_length=50000, verbose_output=1, log='__TEST_DIR__/logs.txt', complete_log='__TEST_DIR__/clog.txt', enable_verification=false);
 
 mode unskip


### PR DESCRIPTION
Sometimes the fuzzers generate (combinations) of statements that have a very long total length.
The consequence is that even if this generates a crash, the issue can not be processed and reproduced correctly, since the statements do not fit in a GitHub issue (generated with GH API).

Examples - note that the issues contain truncated (and therefore invalid) sql-statements:
- https://github.com/duckdb/duckdb-fuzzer/issues/4201
- https://github.com/duckdb/duckdb-fuzzer/issues/4205


With this PR the fuzzer functions are now adjusted, to take argument "max_query_length".
The default in CI (via `scripts/run_fuzzer.py`) is set to 50000 chars).

Adjusted fuzzer functions:
- `sqlsmith`
- `fuzzyduck`
- `fuzz_all_functions`
